### PR TITLE
Fixed top-level unit test names in `createLogger.spec.ts` and `Logger.spec.ts`.

### DIFF
--- a/src/functions/postLogs/application/__tests__/Logger.spec.ts
+++ b/src/functions/postLogs/application/__tests__/Logger.spec.ts
@@ -2,7 +2,7 @@ import { Mock, It, Times } from 'typemoq';
 import LogEvent from '../LogEvent';
 import Logger, { LogDelegate } from '../Logger';
 
-describe('handler', () => {
+describe('Logger', () => {
   const moqLogDelegate = Mock.ofType<LogDelegate>();
   let sut: Logger;
 

--- a/src/functions/postLogs/framework/__tests__/createLogger.spec.ts
+++ b/src/functions/postLogs/framework/__tests__/createLogger.spec.ts
@@ -4,7 +4,7 @@ import { CloudWatchLogs } from 'aws-sdk';
 import * as logger from '../createLogger';
 import { LogDelegate } from '../../application/Logger';
 
-describe('logger', () => {
+describe('logging', () => {
   const originalConsoleLog = console.log;
   const moqConsoleLog = Mock.ofInstance(console.log);
   const moqCreateLogStream = Mock.ofInstance(new CloudWatchLogs().createLogStream);


### PR DESCRIPTION
## MES-1724 Fixed top-level unit test names in `createLogger.spec.ts` and `Logger.spec.ts`.

Very minor changes to fix some unit test names in the logging code in Log Service.

## Pull Request checklist:

- [x] [WIP] tag removed from PR title
- [x] PR has an understandable description

## Git feature branch checklist:

- [x] branch name comply with our branching strategy
- [x] git branch contains relevant JIRA ticket number
- [x] branch rebased against the latest develop
- [ ] commits are squashed

## Sign off process checklist:

- [x] Code has been tested manually
- [x] Tests are passing
- [x] PR link added to JIRA
- [x] Reviewers selected in Github
- [ ] Tested by QA
- [ ] PO's approval
